### PR TITLE
Added Coinbase specific options to the authorization URL

### DIFF
--- a/lib/passport-coinbase/strategy.js
+++ b/lib/passport-coinbase/strategy.js
@@ -53,6 +53,22 @@ function Strategy(options, verify) {
   if(options.scope && options.scope.indexOf('user') < 0) this._skipUserProfile = true;
   this._userProfileURL = options.userProfileURL || 'https://coinbase.com/api/v1/users';
 
+  if (options.account) {
+    this._account = options.account;
+  }
+
+  if (options.send_limit_amount) {
+    this._send_limit_amount = options.send_limit_amount;
+  }
+
+  if (options.send_limit_currency) {
+    this._send_limit_currency = options.send_limit_currency;
+  }
+
+  if (options.send_limit_period) {
+    this._send_limit_period = options.send_limit_period;
+  }
+
   OAuth2Strategy.call(this, options, verify);
 
   this.name = 'coinbase';
@@ -99,6 +115,50 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       done(e);
     }
   });
+};
+
+
+/**
+ * Return extra Coinbase-specific parameters to be included in the authorization
+ * request.
+ *
+ *  See here for details: https://developers.coinbase.com/docs/wallet/coinbase-connect/permissions
+ *
+ * Options:
+ *  - 'account' - Applications can request different access to user’s wallets, { 'select', 'new', 'all' }
+ *  - 'send_limit_amount' - A limit to the amount of money your application can send from the user’s account.
+ *  - 'send_limit_currency' - Currency of send_limit_amount in ISO format, {'BTC', 'USD', etc}
+ *  - 'send_limit_period' - How often the send money limit expires. Default is month, {'day', 'month', 'year'}
+ *
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+Strategy.prototype.authorizationParams = function (options) {
+  var params = {};
+
+  console.log('In authorizationParams');
+
+
+  if (this._account) {
+    params.account = this._account;
+  }
+
+  if (this._send_limit_amount) {
+    params['meta[send_limit_amount]'] = this._send_limit_amount;
+  }
+
+  if (this._send_limit_currency) {
+    params['meta[send_limit_currency]'] = this._send_limit_currency;
+  }
+
+  if (this._send_limit_period) {
+    params['meta[send_limit_period]'] = this._send_limit_period;
+  }
+
+  console.log('params: ' + JSON.stringify(params));
+
+  return params;
 };
 
 


### PR DESCRIPTION
I would like to add the ability to specify the extra options that Coinbase supports on the authorization URL.  See here for information:
https://developers.coinbase.com/docs/wallet/coinbase-connect/permissions
- account
- meta[send_limit_amount]
- meta[send_limit_currency]
- meta[send_limit_period]
